### PR TITLE
Merged Splet commits

### DIFF
--- a/scripts/z_spletfixes_misc.zs
+++ b/scripts/z_spletfixes_misc.zs
@@ -1,0 +1,38 @@
+//------ IC2 GENERATOR ARMOR ------
+recipes.remove(<IC2:itemSolarHelmet>);
+recipes.addShaped(<IC2:itemSolarHelmet>, 
+  [[<minecraft:air>, <IC2:blockGenerator:3>, <minecraft:air>], 
+  [<ore:stickSteel>, <terrafirmacraft:item.Wrought Iron Helmet>, <ore:stickSteel>],
+  [<IC2:itemCable>, <IC2:itemCable>, <IC2:itemCable>]]);
+  
+recipes.remove(<IC2:itemStaticBoots>);
+recipes.addShaped(<IC2:itemStaticBoots>,
+  [[<minecraft:air>, <terrafirmacraft:item.Wrought Iron Boots>, <minecraft:air>], 
+  [<ore:blockWool>, <IC2:itemArmorRubBoots>, <ore:blockWool>],
+  [<IC2:itemCable>, <IC2:itemCable>, <IC2:itemCable>]]);
+
+//you should not be forced to use white wool in your boots
+recipes.remove(<IC2:itemArmorRubBoots>);
+recipes.addShaped(<IC2:itemArmorRubBoots>,
+  [[<ore:itemRubber>, <minecraft:air>, <ore:itemRubber>], 
+  [<ore:itemRubber>, <minecraft:air>, <ore:itemRubber>],
+  [<ore:itemRubber>, <ore:blockWool>, <ore:itemRubber>]]);
+
+ 
+//------ IC2 UNBREAKABLE HAZMAT ------
+mods.techreborn.assemblingMachine.addRecipe(<IC2:itemArmorHazmatHelmet>.withTag({ench:[{lvl:10 as short, id: 34 as short}], Unbreakable: 1, Unbreaking: 10, display: {Name: "Lead-Lined Scuba Helmet"}}), <IC2:itemArmorHazmatHelmet>, <ihl:item.ihlSimpleItem:152>*64, 600, 64);
+mods.techreborn.assemblingMachine.addRecipe(<IC2:itemArmorHazmatChestplate>.withTag({ench:[{lvl:10 as short, id: 34 as short}], Unbreakable: 1, Unbreaking: 10, display: {Name: "Lead-Lined Hazmat Suit"}}), <IC2:itemArmorHazmatChestplate>, <ihl:item.ihlSimpleItem:152>*64, 600, 64);
+mods.techreborn.assemblingMachine.addRecipe(<IC2:itemArmorHazmatLeggings>.withTag({ench:[{lvl:10 as short, id: 34 as short}], Unbreakable: 1, Unbreaking: 10, display: {Name: "Lead-Lined Hazmat Suit Leggings"}}), <IC2:itemArmorHazmatLeggings>, <ihl:item.ihlSimpleItem:152>*64, 600, 64);
+mods.techreborn.assemblingMachine.addRecipe(<IC2:itemArmorRubBoots>.withTag({ench:[{lvl:10 as short, id: 34 as short}], Unbreakable: 1, Unbreaking: 10, display: {Name: "Lead-Lined Rubber Boots"}}), <IC2:itemArmorRubBoots>, <ihl:item.ihlSimpleItem:152>*64, 600, 64);
+
+//------ MISC. METAL FORMER RECIPES ------
+mods.ic2.MetalFormer.addRollingRecipe(<libVulpes:libVulpesproductplate:2>, <terrafirmacraft:item.Gold Ingot>);
+
+mods.ic2.MetalFormer.addExtrudingRecipe(<tfctech:item.Tin Wire>, <tfctech:item.Tin Stripe>);
+mods.ic2.MetalFormer.addExtrudingRecipe(<tfctech:item.Aluminum Wire>, <tfctech:item.Aluminum Stripe>);
+mods.ic2.MetalFormer.addExtrudingRecipe(<tfctech:item.Copper Wire>, <tfctech:item.Copper Stripe>);
+mods.ic2.MetalFormer.addExtrudingRecipe(<tfctech:item.Gold Wire>, <tfctech:item.Gold Stripe>);
+mods.ic2.MetalFormer.addExtrudingRecipe(<tfctech:item.Electrum Wire>, <tfctech:item.Electrum Stripe>);
+mods.ic2.MetalFormer.addExtrudingRecipe(<tfctech:item.Wrought Iron Wire>, <tfctech:item.Wrought Iron Stripe>);
+mods.ic2.MetalFormer.addExtrudingRecipe(<tfctech:item.Steel Wire>, <tfctech:item.Steel Stripe>);
+

--- a/scripts/z_spletfixes_ores.zs
+++ b/scripts/z_spletfixes_ores.zs
@@ -1,0 +1,63 @@
+//------ CRUSHED AND WASHED ORE SPLITTING ------
+//you'll thank me later because compacting drawers will work now
+recipes.addShapeless(<customitems:nativecoppercrush_sm>*4, [<customitems:itemcrushednativecopperore>]);
+recipes.addShapeless(<customitems:nativecopper_smw>*4, [<customitems:itemwashedcrushednativecopperore>]);
+
+recipes.addShapeless(<customitems:nativegoldcrush_sm>*4, [<customitems:itemcrushednativegoldore>]);
+recipes.addShapeless(<customitems:nativegold_smw>*4, [<customitems:itemwashedcrushednativegoldore>]);
+
+recipes.addShapeless(<customitems:nativeplatinumcrush_sm>*4, [<customitems:itemcrushednativeplatinumore>]);
+recipes.addShapeless(<customitems:nativeplatinum_smw>*4, [<customitems:itemwashedcrushednativeplatinumore>]);
+
+recipes.addShapeless(<customitems:hematitecrush_sm>*4, [<customitems:itemcrushedhematiteore>]);
+recipes.addShapeless(<customitems:hematite_smw>*4, [<customitems:itemwashedcrushedhematiteore>]);
+
+recipes.addShapeless(<customitems:nativesilvercrush_sm>*4, [<customitems:itemcrushednativesilverore>]);
+recipes.addShapeless(<customitems:nativesilver_smw>*4, [<customitems:itemwashedcrushednativesilverore>]);
+
+recipes.addShapeless(<customitems:cassiteritecrush_sm>*4, [<customitems:itemcrushedcassiteriteore>]);
+recipes.addShapeless(<customitems:cassiterite_smw>*4, [<customitems:itemwashedcrushedcassiteriteore>]);
+
+recipes.addShapeless(<customitems:galenacrush_sm>*4, [<customitems:itemcrushedgalenaore>]);
+recipes.addShapeless(<customitems:galena_smw>*4, [<customitems:itemwashedcrushedgalenaore>]);
+
+recipes.addShapeless(<customitems:bismuthinitecrush_sm>*4, [<customitems:itemcrushedbismuthiniteore>]);
+recipes.addShapeless(<customitems:bismuthinite_smw>*4, [<customitems:itemwashedcrushedbismuthiniteore>]);
+
+recipes.addShapeless(<customitems:garnieritecrush_sm>*4, [<customitems:itemcrushedgarnieriteore>]);
+recipes.addShapeless(<customitems:garnierite_smw>*4, [<customitems:itemwashedcrushedgarnieriteore>]);
+
+recipes.addShapeless(<customitems:malachitecrush_sm>*4, [<customitems:itemcrushedmalachiteore>]);
+recipes.addShapeless(<customitems:malachite_smw>*4, [<customitems:itemwashedcrushedmalachiteore>]);
+
+recipes.addShapeless(<customitems:magnetitecrush_sm>*4, [<customitems:itemcrushedmagnetiteore>]);
+recipes.addShapeless(<customitems:magnetite_smw>*4, [<customitems:itemwashedcrushedmagnetiteore>]);
+
+recipes.addShapeless(<customitems:limonitecrush_sm>*4, [<customitems:itemcrushedlimoniteore>]);
+recipes.addShapeless(<customitems:limonite_smw>*4, [<customitems:itemwashedcrushedlimoniteore>]);
+
+recipes.addShapeless(<customitems:sphaleritecrush_sm>*4, [<customitems:itemcrushedsphaleriteore>]);
+recipes.addShapeless(<customitems:sphalerite_smw>*4, [<customitems:itemwashedcrushedsphaleriteore>]);
+
+recipes.addShapeless(<customitems:tetrahedritecrush_sm>*4, [<customitems:itemcrushedtetrahedriteore>]);
+recipes.addShapeless(<customitems:tetrahedrite_smw>*4, [<customitems:itemwashedcrushedtetrahedriteore>]);
+
+recipes.addShapeless(<customitems:pitchblendecrush_sm>*4, [<customitems:itemcrushedpitchblendeore>]);
+recipes.addShapeless(<customitems:pitchblende_smw>*4,[<customitems:itemwashedcrushedpitchblendeore>]);
+
+recipes.addShapeless(<customitems:bauxitecrush_sm>*4, [<customitems:itemcrushedbauxiteore>]);
+recipes.addShapeless(<customitems:bauxite_smw>*4, [<customitems:itemwashedcrushedbauxitere>]);
+
+recipes.addShapeless(<customitems:rutile_smw>*4, [<customitems:itemwashedcrushedrutileore>]);
+
+recipes.addShapeless(<customitems:wolframite_smw>*4, [<customitems:itemwashedcrushedwolframiteore>]);
+
+recipes.addShapeless(<customitems:beryl_smw>*4, [<customitems:itemwashedcrushedberylore>]);
+
+//------ RESIDUAL ORE PRODUCTS ------
+//Sb2O3
+recipes.addShapeless(<customitems:tinypileofantimonyoxide>*9, [<ihl:item.ihlSimpleItem:133>]);
+//MgO
+recipes.addShapeless(<customitems:smallpileofmagnesiumoxide>*4, [<ihl:item.ihlSimpleItem:161>]);
+//TiO2
+recipes.addShapeless(<customitems:smallpileoftitaniumdioxide>*9, [<customitems:titaniumdioxide>]);


### PR DESCRIPTION
- All crushed/washed ores can be split into small variants, making them compatible with compacting drawers
- Antimony oxide, magnesium oxide, and titanium dioxide all can be split into small variants, making them compatible with compacting drawers
- Solar helmet and static boots have attainable recipes that have been mildly tweaked to fit
- Rubber boots may now be made with any kind of wool
- An unbreakable set of Hazmat armor can be made using a lot of lead sheets and the TR assembling machine
- Gold can be rolled into plates in the IC2 metal former
- Shurgent's TFCtech strips can be extruded into TFCtech wires in the IC2 metal former